### PR TITLE
Allow nginx (web service) to start independent of sails.

### DIFF
--- a/nginx/default-nossl.conf
+++ b/nginx/default-nossl.conf
@@ -12,9 +12,13 @@ server {
     # prevents 502 Bad Gateway error
     large_client_header_buffers 8 32k;
 
+    # this is the internal Docker DNS, cache only for 30s
+    resolver 127.0.0.11 valid=30s;
+
     # pass any requests to our apiSails service
     location / {
-        proxy_pass http://api_sails:1337;
+        set $upstream http://api_sails:1337;
+        proxy_pass $upstream;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -31,9 +31,13 @@ server {
     # prevents 502 Bad Gateway error
     large_client_header_buffers 8 32k;
 
+    # this is the internal Docker DNS, cache only for 30s
+    resolver 127.0.0.11 valid=30s;
+
     # pass any requests to our api_sails service
     location / {
-        proxy_pass http://api_sails:1337;
+        set $upstream http://api_sails:1337;
+        proxy_pass $upstream;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 


### PR DESCRIPTION
Currently we limit service restarts to 3 after failure. If web tries to start before sails is up, it will fail with:
```
[emerg] 1#1: host not found in upstream "api_sails" in /etc/nginx/conf.d/default
```
This causes issue in our test workflows.

This fix is based on: https://sandro-keil.de/blog/let-nginx-start-if-upstream-host-is-unavailable-or-down/