### PR TITLE
Authentication log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,10 @@ mysql/data/**
 redis/data/**
 !redis/data/.gitkeep
 
-logs
+logs/*
+!/logs/README.md
+!/logs/appbuilder/
+!/logs/fail2ban/
 
 ################################################
 # Miscellaneous

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,31 @@
+## AppBuilder Logs
+
+The `./logs/appbuilder` directory will be bind mounted into the api_sails
+container as `/var/log/appbuilder`. Presently, there is just one use for this:
+ 
+### `auth.log`
+
+This log file keeps track of authentication attempts to the site. This enables
+the host server to respond if the site comes under attack by a brute force
+login script.
+
+One tool for protecting against such attacks is fail2ban. A custom fail2ban 
+filter is provided in `./logs/fail2ban/filter.d/appbuilder.conf`.
+
+
+
+## Nginx logs
+
+You may find it convenient to house your relevant nginx logs in `./logs`. For
+example, in the host server nginx site config:
+
+```nginx
+server {
+  server_name yoursite.example.org;
+  access_log <your AB site directory>/logs/access.log;
+  error_log <your AB site directory>/logs/error.log;
+  listen 443 ssl;
+
+  ...
+}
+```

--- a/logs/fail2ban/filter.d/appbuilder.conf
+++ b/logs/fail2ban/filter.d/appbuilder.conf
@@ -1,0 +1,29 @@
+# Fail2Ban filter for unsuccesful AppBuilder authentication attempts
+#
+#
+# The auth.log file is usually bind mounted in the ./logs/appbuilder directory
+# So in your fail2ban jail.local config file:
+#  [appbuilder]
+#  filter = appbuilder
+#  enabled = true
+#  logpath = <your AB site directory>/logs/appbuilder/auth.log
+#
+
+[INCLUDES]
+
+# Read common prefixes. If any customizations available -- read them from
+# common.local
+before = common.conf
+
+[Definition]
+
+failregex = ^\s+\[<HOST>\]\s+.+FAILED$
+
+ignoreregex = 
+
+# DEV Notes:
+#
+# Example:
+# 2023-01-10T08:53:30.181Z  [192.168.1.1]  Token auth FAILED
+#
+# Author: Digiserve

--- a/source.docker-compose.dev.yml
+++ b/source.docker-compose.dev.yml
@@ -84,6 +84,9 @@ services:
       - COTE_DISCOVERY_REDIS_HOST=redis
     volumes:
       - type: bind
+        source: ./logs/appbuilder/
+        target: /var/log/appbuilder/
+      - type: bind
         source: ./developer/api_sails
         target: /app
       - config:/app/config

--- a/source.docker-compose.yml
+++ b/source.docker-compose.yml
@@ -79,6 +79,9 @@ services:
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
     volumes:
+      - type: bind
+        source: ./logs/appbuilder/
+        target: /var/log/appbuilder/
       - config:/app/config
       - files:/data
     depends_on:


### PR DESCRIPTION
Changelog
- Added new directory `./logs/appbuilder`
- Bind this directory to the api_sails container as `/var/log/appbuilder`
- Documentation

Separately, in ab_service_api_sails, all authentication attempts (local, auth token, relay token) will be logged to `./logs/appbuilder/auth.log`.

See https://github.com/digi-serve/planning/issues/545
