### PR TITLE
HTTP headers for better security

### DIFF
--- a/nginx/default-nossl.conf
+++ b/nginx/default-nossl.conf
@@ -40,6 +40,12 @@ server {
     # /home
     # redirect to /app/assets/index.html
     location = /home {
+        # Prevent frame click-jacking from other domains
+        add_header X-Frame-Options SAMEORIGIN always;
+
+        # Tell browser to only use encrypted HTTPS on this site for 1 year
+        add_header Strict-Transport-Security 3153600;
+        
         add_header Cache-Control "no-cache";
         # don't cache so the most uptodate js files are requested
         root /app/assets;


### PR DESCRIPTION
This adds two of the recommended HTTP headers put forth by Zach's vulnerability scan.

Note: `Strict-Transport-Security` will have no effect if the site was never loaded via HTTPS in the first place. So this won't conflict with local testing.