### PR TITLE
Added Docker volume for ClamAV database

### DIFF
--- a/source.docker-compose.yml
+++ b/source.docker-compose.yml
@@ -9,6 +9,7 @@ volumes:
   mysql_password:
   nginx_etc:
   redis_data:
+  clamav:
     
 networks:
   default:
@@ -154,9 +155,12 @@ services:
     image: digiserve/ab-file-processor:<%=tag%>
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
+      # Set CLAMAV_ENAMED=true to enable. Disabled by default.
+      - CLAMAV_ENABLED
     volumes:
       - config:/app/config
       - files:/data
+      - clamav:/var/lib/clamav
     depends_on:
       - redis
       - config


### PR DESCRIPTION
This matches the change to the production runtime:
https://github.com/digi-serve/ab-production-runtime/commit/15050b8b9b8528c3c43e2c0e240d3ab858916f21

Related to this other PR:
https://github.com/digi-serve/ab_service_file_processor/pull/5