### PR TITLE
Fix DB Reset in E2E tests

### DIFF
--- a/test/setup/ci-test.overide.yml
+++ b/test/setup/ci-test.overide.yml
@@ -13,12 +13,9 @@ services:
       - type: bind
         source: ./test/setup/reset.sh
         target: /reset.sh
-      - type: bind
-        source: ./mysql/init/02-tenant_manager.sql
-        target: /sql/reset_tenant.sql
-      - type: bind
-        source: ./mysql/init/03-site_tables.sql
-        target: /sql/reset.sql
+     - type: bind
+        source: ./test/setup/reset-user.sql
+        target: /reset.sh
   #/db
 
   #api_sails: our API end point

--- a/test/setup/ci-test.overide.yml
+++ b/test/setup/ci-test.overide.yml
@@ -15,7 +15,7 @@ services:
         target: /reset.sh
      - type: bind
         source: ./test/setup/reset-user.sql
-        target: /reset.sh
+        target: /reset-user.sql
   #/db
 
   #api_sails: our API end point

--- a/test/setup/ci-test.overide.yml
+++ b/test/setup/ci-test.overide.yml
@@ -13,7 +13,7 @@ services:
       - type: bind
         source: ./test/setup/reset.sh
         target: /reset.sh
-     - type: bind
+      - type: bind
         source: ./test/setup/reset-user.sql
         target: /reset-user.sql
   #/db

--- a/test/setup/reset.sh
+++ b/test/setup/reset.sh
@@ -23,5 +23,6 @@ DEALLOCATE PREPARE stmt; " \
 echo "SET FOREIGN_KEY_CHECKS = 1;" >> ./drop_all_tables.sql
 
 mysql -u $DB_USER -p$DB_PASSWORD "appbuilder-$TENANT" < ./drop_all_tables.sql
-mysql -u $DB_USER -p$DB_PASSWORD "appbuilder-$TENANT" < ./sql/reset.sql
-mysql -u $DB_USER -p$DB_PASSWORD "appbuilder-$TENANT" < ./sql/reset_tenant.sql
+mysql -u $DB_USER -p$DB_PASSWORD "appbuilder-$TENANT" < ./docker-entrypoint-initdb.d/03-site_tables.sql
+mysql -u $DB_USER -p$DB_PASSWORD "appbuilder-$TENANT" < ./docker-entrypoint-initdb.d/02-tenant_manager.sql
+mysql -u $DB_USER -p$DB_PASSWORD "appbuilder-$TENANT" < ./reset-user.sql

--- a/test/setup/test-compose.yml
+++ b/test/setup/test-compose.yml
@@ -23,7 +23,7 @@ services:
         target: /reset.sh
       - type: bind
         source: ./test/setup/reset-user.sql
-        target: /reset.sh
+        target: /reset-user.sql
   #/db
 
   #api_sails: our API end point

--- a/test/setup/test-compose.yml
+++ b/test/setup/test-compose.yml
@@ -22,11 +22,8 @@ services:
         source: ./test/setup/reset.sh
         target: /reset.sh
       - type: bind
-        source: ./mysql/init/02-tenant_manager.sql
-        target: /sql/reset_tenant.sql
-      - type: bind
-        source: ./mysql/init/03-site_tables.sql
-        target: /sql/reset.sql
+        source: ./test/setup/reset-user.sql
+        target: /reset.sh
   #/db
 
   #api_sails: our API end point

--- a/testReset.sh
+++ b/testReset.sh
@@ -14,7 +14,7 @@ then
 else
 	docker exec $ID_Service bash reset.sh
 	docker run \
-        -v ${STACK}_config:/app/config/ \
+        --env-file .env\
         --network=${STACK}_default \
         digiserve/ab-migration-manager:master node app.js
 fi


### PR DESCRIPTION
Update our DB reset scripts to work with changes to the stack (No `config` service and new `db` service) 