### PR TITLE
Include a -t flag for migrate.sh to run migrations on the testi…

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -3,23 +3,36 @@
 # Uses the AB Migration Manager to update every tenant DB to the latest
 # schema.
 
-
 # Import ENV variables
 set -o allexport
 source .env
 set +o allexport
 
+Test=
+# Read flags -t for test
+while getopts dtq name
+do
+    case $name in
+    t)    Test="true";;
+    esac
+done
+
+STACK="${STACKNAME}"
+if [[ -n $Test ]]
+then
+  STACK="${CYPRESS_STACK}"
+fi
 
 ${PLATFORM} pull docker.io/digiserve/ab-migration-manager:master
 
 SCRIPT_DIR=`dirname -- $0`
-ID=`${PLATFORM} container ls -f name=${STACKNAME}_api_sails`
+ID=`${PLATFORM} container ls -f name=${STACK}_api_sails`
 if [ "$ID" == "" ]
 then
-    echo "${STACKNAME} is not running"
+    echo "${STACK} is not running"
 else
     ${PLATFORM} run \
-        --network=${STACKNAME}_default \
+        --network=${STACK}_default \
         -e MYSQL_PASSWORD \
         digiserve/ab-migration-manager:master node app.js
 fi

--- a/migrate.sh
+++ b/migrate.sh
@@ -10,7 +10,7 @@ set +o allexport
 
 Test=
 # Read flags -t for test
-while getopts dtq name
+while getopts t name
 do
     case $name in
     t)    Test="true";;


### PR DESCRIPTION
When working with the testing environment, it would be helpful if our cli scripts could have the `-t` option to run against the testing setup.

## Release Notes
<!-- #release_notes -->
- [add] Include a -t flag for migrate.sh to run migrations on the testng environment.
<!-- /release_notes --> 
