### PR TITLE
Adding Additional Cy Commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-cypress": "^2.12.1",
-    "eslint-plugin-prettier": "^4.2.1"
+    "eslint-plugin-prettier": "^5.0.0"
   },
   "dependencies": {
     "@digiserve/ab-utils": "^1.6.0",

--- a/test/e2e/cypress/e2e/0003_import_cars.cy.js
+++ b/test/e2e/cypress/e2e/0003_import_cars.cy.js
@@ -24,7 +24,7 @@ describe("CARS:", () => {
       NavigateCars(cy);
 
       // Should show CARS in the Menu Title
-      cy.get("[data-cy=portal_work_menu_title]")
+      cy.get("[data-cy=portal_work_menu_title]", { timeout: 90000 })
          .should("be.visible")
          .should("have.text", "CARS");
 

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -37,6 +37,46 @@ Cypress.Commands.add("AuthLogin", () => {
    });
 });
 
+Cypress.Commands.add("ModelCreate", (ID, data) => {
+   cy.window().then((win) => {
+      let AB = win.AB;
+      if (AB) {
+         return AB.objectByID(ID).model().create(data);
+      }
+      return null;
+   });
+});
+
+Cypress.Commands.add("ModelDelete", (idModel, idRow) => {
+   cy.window().then((win) => {
+      let AB = win.AB;
+      if (AB) {
+         return AB.objectByID(idModel).model().delete(idRow);
+      }
+      return null;
+   });
+});
+
+Cypress.Commands.add("ModelFind", (idModel, cond) => {
+   cy.window().then((win) => {
+      let AB = win.AB;
+      if (AB) {
+         return AB.objectByID(idModel).model().findAll(cond);
+      }
+      return null;
+   });
+});
+
+Cypress.Commands.add("ModelUpdate", (idModel, idRow, data) => {
+   cy.window().then((win) => {
+      let AB = win.AB;
+      if (AB) {
+         return AB.objectByID(idModel).model().update(idRow, data);
+      }
+      return null;
+   });
+});
+
 Cypress.Commands.add("ResetDB", () => {
    const stack = Cypress.env("STACK");
 

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -115,13 +115,13 @@ Cypress.Commands.add("RunSQL", (folder, files, fail = true) => {
          `docker cp ./cypress/e2e/${folder}/test_setup/sql/combineSql.sql ${containerId}:/sql/combineSql.sql`,
          {
             log: false,
-         }
+         },
       );
 
       cy.exec(
          /* eslint-disable no-useless-escape*/
          `docker exec ${containerId} bash -c "mysql -u ${user} -p${password} \"appbuilder-admin\" < ./sql/combineSql.sql"`,
-         { failOnNonZeroExit: fail }
+         { failOnNonZeroExit: fail },
       );
       cy.exec(`docker exec ${containerId} bash -c "rm ./sql/combineSql.sql"`, {
          log: false,


### PR DESCRIPTION
This update adds additional cy.commands for working with data through an Object's model.

We will need to convert many of our tests that are directly manipulating data via API calls, to now work through the associated models.

NOTE: I also increased the timeout on our CARS import to be more friendly to slower systems like mine.

## Release Notes
<!-- #release_notes -->
- [add] Additional cy commands to work with an Object's data using it's Model
- [fix] fixes an eslint related error when eslint v8 and eslint-plugin-prettier < v5
- [wip] eslint changes
- [fix] increasing timeout for slower systems like mine
<!-- /release_notes --> 
