### PR TITLE
block outgoing sentry requests from cypress tests

### DIFF
--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -18,3 +18,8 @@ import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+beforeEach(() => {
+   // block/stub outgoing requests to sentry
+   cy.intercept({ hostname: /sentry\.io/ }, (req) => req.reply("success"));
+});


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- block outgoing sentry requests from cypress tests
<!-- /release_notes --> 
