### PR TITLE
Pull the GridScroll() routine into our cypress commands to be used in more places

### DIFF
--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -61,6 +61,19 @@ Cypress.Commands.add("DCSetCursor", (idDC, idRow) => {
    });
 });
 
+/**
+ * helper for scrolling in a grid
+ * @function gridScroll
+ * @param {string} id webix id of the grid
+ * @param {int} h horizontal scroll in pixels
+ * @param {int=0} v veritcal scroll in pixels
+ */
+Cypress.Commands.add("GridScroll", (id, h, v = 0) => {
+   cy.window().then((win) => {
+      return win.$$(id).scrollTo(h, v);
+   });
+});
+
 Cypress.Commands.add("ModelCreate", (ID, data) => {
    cy.window().then((win) => {
       let AB = win.AB;


### PR DESCRIPTION
I needed to use the GridScroll() routine from the Grid test in the Datacollection tests.  So I made it a global command.

## Release Notes
<!-- #release_notes -->
- [add] pull the GridScroll() routine into our cypress commands to be used in more places
<!-- /release_notes --> 

## Test Status
This is so I can use the command in our Tests